### PR TITLE
Mason sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ of origin. Users can invoke a read simulator on the simulated structures to gene
 
 It takes as input a reference genome fasta and a yaml configuration file.
 
-The latest version of ecSimulator is **0.6.0**.
+The latest version of ecSimulator is **0.7.1**.
 
 ## Requirements and Installation
-### Basic requirements:
-ecSimulator requires python3 and the `numpy` and `intervaltree` python libraries.
+### Basic requirements
+ecSimulator requires python >=3 and the `numpy` and `intervaltree` python libraries.
 
 ```shell
-pip3 install numpy intervaltree  # or conda install intervaltree, etc.
+conda install numpy intervaltree  # or pip3 install numpy intervaltree
 git clone https://github.com/jluebeck/ecSimulator.git
 ```
 
@@ -35,10 +35,11 @@ ecSimulator also requires the AmpliconArchitect data repo to be present, which c
 A reference genome fasta file from which to extract genome sequences is also required.
 These are available in the [AmpliconArchitect data repo](https://datasets.genepattern.org/?prefix=data/module_support_files/AmpliconArchitect/) for users who may already have that tool installed.
 
-### Optional dependencies for read simulation:
+### Optional dependencies for read simulation
+ecSimulator enables users to simulate reads from the resulting structures, using Nanopore or Illumina read simulators.
 
-ecSimulator allows users to simulate nanopore reads from the resulting structures, using [NanoSim](https://github.com/bcgsc/NanoSim).
-Nanosim can be installed by performing
+#### Nanopore: NanoSim
+[NanoSim](https://github.com/bcgsc/NanoSim) can be installed by running
 ```shell
 conda install -c bioconda nanosim
 ```
@@ -46,12 +47,21 @@ conda install -c bioconda nanosim
 We provide a pre-generated NanoSim read simulation model generated using input data from a Promethion with version 10.4.1 flow cell and Guppy as the basecaller (version dna_r10.4.1_e8.2_400bps_hac@v3.5.2).
 No additional configuration of the simulator is required by the user.
 
-### Computing requirements:
+
+#### Illumina: Mason2
+[Mason2](https://github.com/seqan/seqan/tree/main/apps/mason2) can be installed by running
+```shell
+conda install -c bioconda mason
+```
+
+
+
+### Computing requirements
 The memory an CPU requirements of ecSimulator are minimal, but please try to have more than 4Gb RAM available. The simulator should finish within 30s-1min for typical simulation runs.
-Simulating thousands of structures may take slightly longer.
+Simulating thousands of structures may take slightly longer. Read simulation is more resource intensive, and timing varies by the tool used and depth of coverage given.
 
 ## Usage
-### Focal amplification simulation:
+### Focal amplification simulation
 An example command to generate an ecDNA of episomal origin with at least two non-overlapping genomic segments
 with default SV frequencies:
 >`ecSimulator/src/ecSimulator.py --ref_name GRCh38 --ref_fasta /path/to/hg38.fa -o test`
@@ -59,10 +69,19 @@ with default SV frequencies:
 Or with customized simulation parameters:
 >`ecSimulator/src/ecSimulator.py --ref_name GRCh38 --ref_fasta /path/to/hg38.fa --config_file your_config.yaml -o test`
 
-### Nanopore read simulation:
+### Nanopore read simulation
 
-To simulate Nanopore reads from the simulated focal amplification (using NanoSim), you can do the following
->`ecSimulator/src/run_nanosim.py -o test_amplicon_1_read_sim --amplicon_fasta test_amplicon1.fasta --amplicon_coverage 1`
+To simulate Nanopore reads from the simulated focal amplification using NanoSim, you can do the following
+>`ecSimulator/src/run_nanosim.py -t [threads] -o test_amplicon_1_nanosim --amplicon_fasta test_amplicon1.fasta --amplicon_coverage 1`
+
+Check with `-h` to see other arguments for setting background regions, and adjusting other read simulation parameters.
+
+### Illumina read simulation
+To simulate Illumina reads from the simulated focal amplification using Mason, you can do the following
+>`ecSimulator/src/run_mason.py -t [threads] -o test_amplicon_1_mason --amplicon_fasta test_amplicon1.fasta --amplicon_coverage 1`
+
+Check with `-h` to see other arguments for setting background regions, and adjusting other read simulation parameters.
+
 
 ## Options
 ecSimulator takes the following command-line arguments:
@@ -120,8 +139,10 @@ This can be useful if you later want to create mixtures of heterogeneous but hig
 
 **Users can use the `cycles_file_to_fasta.py` script to convert any intermediate (or generally, any) AA-formatted `_cycles.txt` file to a fasta.**
 
-The Nanosim process will create two fastq files (aligned.fastq and unaligned.fastq) and a file describing the locations of the errors in the reads. A complete description of these files is available [here](https://github.com/bcgsc/NanoSim#2-simulation-stage-1).
+### NanoSim outputs
 
-To combine the background and amplicon fastq files, users an simply do
+The NanoSim process will create two fastq files (aligned.fastq and unaligned.fastq) and a file describing the locations of the errors in the reads. A complete description of these files is available [here](https://github.com/bcgsc/NanoSim#2-simulation-stage-1).
+
+To combine the background and amplicon fastq files, users can simply do
 >`cat [sample]_amplicon_unaligned_reads.fastq [sample]_amplicon_aligned_reads.fastq
 [sample]_background_unaligned_reads.fastq [sample]_background_aligned_reads.fastq`

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,2 +1,2 @@
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 __author__ = "Jens Luebeck (jluebeck [ at] ucsd.edu)"

--- a/src/run_mason.py
+++ b/src/run_mason.py
@@ -53,7 +53,6 @@ def run_mason(fasta, mason_path, output_prefix, read_length, coverage, circ_or_l
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Call Mason to simulate nanopore reads from amplicon genome "
                                                  "structures and background genome regions.")
-    parser.add_argument("--mason_path", help="Path to Mason executable.", required=True)
     parser.add_argument("-o", "--output_prefix", help="Prefix for output filenames.", required=True)
     parser.add_argument("--amplicon_fasta", help="Fasta file of simulated amplicon structure.", required=True)
     parser.add_argument("--amplicon_coverage", type=float, help="Coverage for amplicon region - scale up to simulate "
@@ -67,6 +66,8 @@ if __name__ == '__main__':
     parser.add_argument("-t", "--num_threads", type=int, help="Number of threads to use in all stages (default=1).",
                         default=1)
     parser.add_argument("--seed", help="Manually seed the pseudo-random number generator for the simulation.")
+    parser.add_argument("--mason_path", help="Custom path to Mason executable (mason_simulator).", default='mason_simulator')
+
     
     # Note: this parameter is not used for now.
     parser.add_argument("--amp_is_linear", action='store_true', help="Set if the simulated amplicon is linear instead"
@@ -78,12 +79,16 @@ if __name__ == '__main__':
 
     circular_or_linear = "linear" if args.amp_is_linear else "circular"
 
-    # set the nanopore read simulation model
+    # set the path of the mason read simulation tool
+    if not args.mason_path.endswith('mason_simulator') and args.mason_path != 'mason_simulator':
+        args.mason_path += "/mason_simulator"
+
     check_mason_path(args.mason_path)
 
     # simulate reads from the amplicon
     print("Simulating reads from amplicon...")
     amplicon_prefix = args.output_prefix + "_amplicon_reads"
+    background_prefix = args.output_prefix + "_background_reads"
     run_mason(
         args.amplicon_fasta,
         args.mason_path,
@@ -102,7 +107,7 @@ if __name__ == '__main__':
         run_mason(
             args.background_fasta,
             args.mason_path,
-            amplicon_background_prefixrefix,
+            background_prefix,
             args.read_length,
             args.background_coverage,
             "linear",

--- a/src/run_mason.py
+++ b/src/run_mason.py
@@ -4,12 +4,11 @@ Simulates short-read Illumina data from amplicon sequences using Mason.
 """
 
 import argparse
-from math import ceil
 from subprocess import call
 import os
 import sys
 
-from . import utilities
+from utilities import compute_number_of_reads_to_simulate, get_fasta_length
 
 
 def check_mason_path(mason_path=None):
@@ -35,12 +34,12 @@ def run_mason(fasta, mason_path, output_prefix, read_length, coverage, circ_or_l
     Returns:
         None. Call Mason to simulate data.
     """
-    fasta_length = utilities.get_fasta_length(fasta)
-    num_reads = str(utilities.compute_number_of_reads_to_simulate(coverage, fasta_length, read_length))
+    fasta_length = get_fasta_length(fasta)
+    num_reads = str(compute_number_of_reads_to_simulate(coverage, fasta_length, read_length))
 
     R1 = f"{output_prefix}_R1.fastq.gz"
     R2 = f"{output_prefix}_R2.fastq.gz"
-    cmd = "{} -ir {} -n {} --illumina-read_length {} --seq-technology illumina --num-threads {} -o {} -or {}".format(
+    cmd = "{} -ir {} -n {} --illumina-read-length {} --seq-technology illumina --num-threads {} -o {} -or {}".format(
         mason_path, fasta, num_reads, read_length, nthreads, R1, R2
     )
 

--- a/src/run_mason.py
+++ b/src/run_mason.py
@@ -35,7 +35,7 @@ def run_mason(fasta, mason_path, output_prefix, read_length, coverage, circ_or_l
         None. Call Mason to simulate data.
     """
     fasta_length = get_fasta_length(fasta)
-    num_reads = str(compute_number_of_reads_to_simulate(coverage, fasta_length, read_length))
+    num_reads = str(compute_number_of_reads_to_simulate(coverage, fasta_length, 2*read_length))
 
     R1 = f"{output_prefix}_R1.fastq.gz"
     R2 = f"{output_prefix}_R2.fastq.gz"

--- a/src/run_mason.py
+++ b/src/run_mason.py
@@ -9,6 +9,8 @@ from subprocess import call
 import os
 import sys
 
+from . import utilities
+
 
 def check_mason_path(mason_path=None):
     if not os.path.isfile(mason_path):
@@ -33,8 +35,8 @@ def run_mason(fasta, mason_path, output_prefix, read_length, coverage, circ_or_l
     Returns:
         None. Call Mason to simulate data.
     """
-    fasta_length = utililties.get_fasta_length(fasta)
-    num_reads = str(utililties.compute_number_of_reads_to_simulate(coverage, fasta_length, read_length))
+    fasta_length = utilities.get_fasta_length(fasta)
+    num_reads = str(utilities.compute_number_of_reads_to_simulate(coverage, fasta_length, read_length))
 
     R1 = f"{output_prefix}_R1.fastq.gz"
     R2 = f"{output_prefix}_R2.fastq.gz"
@@ -58,6 +60,7 @@ if __name__ == '__main__':
     parser.add_argument("--amplicon_coverage", type=float, help="Coverage for amplicon region - scale up to simulate "
                                                                 "higher amplicon CNs", required=True)
 
+    parser.add_argument("-l", "--read_length", help="Read length", type=int, default=150)
     parser.add_argument("--background_fasta", help="Fasta file of background genome regions. Do not provide if you want"
                                                    " reads from amplicon only")
     parser.add_argument("--background_coverage", type=float, help="Coverage for background region - scale up to "

--- a/src/run_mason.py
+++ b/src/run_mason.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Simulates short-read Illumina data from amplicon sequences using Mason.
+"""
+
+import argparse
+from math import ceil
+from subprocess import call
+import os
+import sys
+
+
+def check_mason_path(mason_path=None):
+    if not os.path.isfile(mason_path):
+
+        raise Exception("Cannot find Mason. Specify an existing file path for " 
+                        " Mason.")
+
+def run_mason(fasta, mason_path, output_prefix, read_length, coverage, circ_or_linear, nthreads, seed=None):
+    """Simulates short-read data with Mason.
+
+    Args:
+        fasta: Path to FASTA file containing amplicon.
+        mason_path: Path to Mason executable.
+        output_prefix: Prefix for file path to write out simulated read data.
+        read_length: Read length for simulated Illumina data (e.g., 150).
+        coverage: Target coverage for amplicon.
+        circ_or_linear: Whether or not to simulate reads from a circular or
+            linear amplicon. (Note used currently.)
+        nthreads: Number of threads to utilize.
+        seed: Random seed to utilize.
+
+    Returns:
+        None. Call Mason to simulate data.
+    """
+    fasta_length = utililties.get_fasta_length(fasta)
+    num_reads = str(utililties.compute_number_of_reads_to_simulate(coverage, fasta_length, read_length))
+
+    R1 = f"{output_prefix}_R1.fastq.gz"
+    R2 = f"{output_prefix}_R2.fastq.gz"
+    cmd = "{} -ir {} -n {} --illumina-read_length {} --seq-technology illumina --num-threads {} -o {} -or {}".format(
+        mason_path, fasta, num_reads, read_length, nthreads, R1, R2
+    )
+
+    if seed:
+        cmd+=(" --seed " + str(seed))
+
+    print(cmd)
+    call(cmd, shell=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Call Mason to simulate nanopore reads from amplicon genome "
+                                                 "structures and background genome regions.")
+    parser.add_argument("--mason_path", help="Path to Mason executable.", required=True)
+    parser.add_argument("-o", "--output_prefix", help="Prefix for output filenames.", required=True)
+    parser.add_argument("--amplicon_fasta", help="Fasta file of simulated amplicon structure.", required=True)
+    parser.add_argument("--amplicon_coverage", type=float, help="Coverage for amplicon region - scale up to simulate "
+                                                                "higher amplicon CNs", required=True)
+
+    parser.add_argument("--background_fasta", help="Fasta file of background genome regions. Do not provide if you want"
+                                                   " reads from amplicon only")
+    parser.add_argument("--background_coverage", type=float, help="Coverage for background region - scale up to "
+                                                                  "simulate lower amplicon CNs")
+    parser.add_argument("-t", "--num_threads", type=int, help="Number of threads to use in all stages (default=1).",
+                        default=1)
+    parser.add_argument("--seed", help="Manually seed the pseudo-random number generator for the simulation.")
+    
+    # Note: this parameter is not used for now.
+    parser.add_argument("--amp_is_linear", action='store_true', help="Set if the simulated amplicon is linear instead"
+                                                                     " of circular.")
+    args = parser.parse_args()
+    if args.background_fasta and not args.background_coverage:
+        print("--background_coverage required if --background_fasta is provided!")
+        sys.exit(1)
+
+    circular_or_linear = "linear" if args.amp_is_linear else "circular"
+
+    # set the nanopore read simulation model
+    check_mason_path(args.mason_path)
+
+    # simulate reads from the amplicon
+    print("Simulating reads from amplicon...")
+    amplicon_prefix = args.output_prefix + "_amplicon_reads"
+    run_mason(
+        args.amplicon_fasta,
+        args.mason_path,
+        amplicon_prefix,
+        args.read_length,
+        args.amplicon_coverage,
+        circular_or_linear,
+        args.num_threads,
+        args.seed
+    )
+
+    # simulate reads from the background
+    if args.background_fasta:
+        print("\nSimulating reads from background...")
+        background_prefix = args.output_prefix + "_background_reads"
+        run_mason(
+            args.background_fasta,
+            args.mason_path,
+            amplicon_background_prefixrefix,
+            args.read_length,
+            args.background_coverage,
+            "linear",
+            args.num_threads,
+            args.seed
+        )

--- a/src/run_nanosim.py
+++ b/src/run_nanosim.py
@@ -6,7 +6,7 @@ from subprocess import call
 import os
 import sys
 
-from . import utililties
+from . import utilities
 
 # this script will run the nanosim pipeline to simulate nanopore reads from ecDNA and background genome.
 # it assumes nanosim is installed and its scripts are on the system path (true if installed by conda).
@@ -23,8 +23,8 @@ def extract_nanosim_model(model_path):
 
 
 def run_nanosim(fasta, model_pre, output_pre, coverage, circ_or_linear, read_length_tuple, nthreads, seed=None):
-    fasta_length = utililties.get_fasta_length(fasta)
-    num_reads = str(utililties.compute_number_of_reads_to_simulate(coverage, fasta_length, model_mean_read_length))
+    fasta_length = utilities.get_fasta_length(fasta)
+    num_reads = str(utilities.compute_number_of_reads_to_simulate(coverage, fasta_length, model_mean_read_length))
 
     cmd = "simulator.py genome -rg {} -c {} -o {} -n {} -dna_type {} -t {} -b guppy --fastq".format(
         fasta, model_pre, output_pre, num_reads, circ_or_linear, str(nthreads))

--- a/src/run_nanosim.py
+++ b/src/run_nanosim.py
@@ -6,7 +6,7 @@ from subprocess import call
 import os
 import sys
 
-from . import utilities
+from utilities import compute_number_of_reads_to_simulate, get_fasta_length
 
 # this script will run the nanosim pipeline to simulate nanopore reads from ecDNA and background genome.
 # it assumes nanosim is installed and its scripts are on the system path (true if installed by conda).

--- a/src/run_nanosim.py
+++ b/src/run_nanosim.py
@@ -6,6 +6,8 @@ from subprocess import call
 import os
 import sys
 
+from . import utililties
+
 # this script will run the nanosim pipeline to simulate nanopore reads from ecDNA and background genome.
 # it assumes nanosim is installed and its scripts are on the system path (true if installed by conda).
 
@@ -16,32 +18,13 @@ def extract_nanosim_model(model_path):
     if not os.path.isdir(model_path):
         print("Extracting model files...")
         cmd = "tar -xzf {}".format(model_path + ".tar.gz")
-        print(cmd)
+        print(cmd) 
         call(cmd, shell=True)
 
 
-def get_fasta_length(fasta):
-    tlen = 0
-    with open(fasta) as infile:
-        for line in infile:
-            if line.startswith(">"):
-                continue
-
-            tlen+=len(line.rstrip())
-
-    print("Fasta size is " + str(tlen) + "bp")
-    return tlen
-
-
-def compute_number_of_reads_to_simulate(coverage, fasta_len, mean_rl):
-    nreads = int(ceil(coverage * fasta_len / mean_rl))
-    print("Number of reads to simulate for {}x coverage: {}".format(str(coverage), str(nreads)))
-    return nreads
-
-
 def run_nanosim(fasta, model_pre, output_pre, coverage, circ_or_linear, read_length_tuple, nthreads, seed=None):
-    fasta_length = get_fasta_length(fasta)
-    num_reads = str(compute_number_of_reads_to_simulate(coverage, fasta_length, model_mean_read_length))
+    fasta_length = utililties.get_fasta_length(fasta)
+    num_reads = str(utililties.compute_number_of_reads_to_simulate(coverage, fasta_length, model_mean_read_length))
 
     cmd = "simulator.py genome -rg {} -c {} -o {} -n {} -dna_type {} -t {} -b guppy --fastq".format(
         fasta, model_pre, output_pre, num_reads, circ_or_linear, str(nthreads))

--- a/src/run_nanosim.py
+++ b/src/run_nanosim.py
@@ -23,8 +23,8 @@ def extract_nanosim_model(model_path):
 
 
 def run_nanosim(fasta, model_pre, output_pre, coverage, circ_or_linear, read_length_tuple, nthreads, seed=None):
-    fasta_length = utilities.get_fasta_length(fasta)
-    num_reads = str(utilities.compute_number_of_reads_to_simulate(coverage, fasta_length, model_mean_read_length))
+    fasta_length = get_fasta_length(fasta)
+    num_reads = str(compute_number_of_reads_to_simulate(coverage, fasta_length, model_mean_read_length))
 
     cmd = "simulator.py genome -rg {} -c {} -o {} -n {} -dna_type {} -t {} -b guppy --fastq".format(
         fasta, model_pre, output_pre, num_reads, circ_or_linear, str(nthreads))

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -17,6 +17,39 @@ def get_fasta_length(fasta):
     return tlen
 
 
+def pseudocircularize_fasta(fasta, c):
+    # read a fasta and makes c copies of each entry concatenated with itself
+    # writes a new fasta and return the path of that file
+    base, ext = os.path.splitext(fasta)
+    output_fasta = f"{base}_circularized{ext}"
+
+    with open(fasta, 'r') as infile, open(output_fasta, 'w') as outfile:
+        seq_name = ""
+        seq_data = ""
+
+        for line in infile:
+            if line.startswith('>'):
+                # Write the previous entry if it exists
+                if seq_name and seq_data:
+                    pseudocircularized_seq = seq_data * c
+                    outfile.write(f"{seq_name}\n")
+                    outfile.write(f"{pseudocircularized_seq}\n")
+
+                # Start a new entry
+                seq_name = line.strip()
+                seq_data = ""
+            else:
+                seq_data += line.strip()
+
+        # Write the last entry
+        if seq_name and seq_data:
+            pseudocircularized_seq = seq_data * c
+            outfile.write(f"{seq_name}\n")
+            outfile.write(f"{pseudocircularized_seq}\n")
+
+    return output_fasta
+
+
 def compute_number_of_reads_to_simulate(coverage, fasta_len, mean_rl):
     nreads = int(ceil(coverage * fasta_len / mean_rl))
     print("Number of reads to simulate for {}x coverage: {}".format(str(coverage), str(nreads)))

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,0 +1,3 @@
+"""
+File for basic utilities.
+"""

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,3 +1,23 @@
 """
 File for basic utilities.
 """
+from math import ceil
+
+
+def get_fasta_length(fasta):
+    tlen = 0
+    with open(fasta) as infile:
+        for line in infile:
+            if line.startswith(">"):
+                continue
+
+            tlen+=len(line.rstrip())
+
+    print("Fasta size is " + str(tlen) + "bp")
+    return tlen
+
+
+def compute_number_of_reads_to_simulate(coverage, fasta_len, mean_rl):
+    nreads = int(ceil(coverage * fasta_len / mean_rl))
+    print("Number of reads to simulate for {}x coverage: {}".format(str(coverage), str(nreads)))
+    return nreads


### PR DESCRIPTION
Implemented simple wrapper around Mason for simulating short-read Illumina data from amplicons.

Example invocation via command line:

`python ./software/ecSimulator/src/run_mason.py --mason_path ./software/mason2-2.0.9-Linux-x86_64/bin/mason_simulator -o ./test --amplicon_fasta ./amplicon1.fasta --amplicon_coverage 20 --num_threads 4`